### PR TITLE
Add option to filter by a capabilities paramater in getPublicKeys.

### DIFF
--- a/bedrock/test.js
+++ b/bedrock/test.js
@@ -4,7 +4,7 @@
 var bedrock = require('bedrock');
 var config = bedrock.config;
 require('bedrock-mongodb');
-require('../lib/main.js');
+require('../lib');
 
 bedrock.events.on('bedrock.test.configure', function() {
   // mongodb config

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,17 +257,33 @@ api.getPublicKey = function(publicKey, actor, callback) {
  * @param id the ID of the identity to get the PublicKeys for.
  * @param actor the Identity performing the action (if `undefined`, private
  *          keys will be removed from the results).
+ * @param [options] the options to use:
+ *           [capability] one or more key capabilities (e.g. 'sign'); this
+ *             restricts the keys to return based on capabilities possessed
+ *             option by the key or its pairing (e.g. 'sign' will only return
+ *             public keys that can be used to identify a paired private key
+ *             that is available for signing).
  * @param callback(err, records) called once the operation completes.
  */
-api.getPublicKeys = function(id, actor, callback) {
+api.getPublicKeys = function(id, actor, options, callback) {
+  if(typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
   if(typeof actor === 'function') {
     callback = actor;
     actor = undefined;
   }
+  options = options || {};
   async.auto({
     find: function(callback) {
-      database.collections.publicKey.find(
-        {owner: database.hash(id)}, {}).toArray(callback);
+      var query = {
+        owner: database.hash(id)
+      };
+      if(options.capability === 'sign') {
+        query['publicKey.privateKey'] = {$exists: true};
+      }
+      database.collections.publicKey.find(query, {}).toArray(callback);
     },
     checkPermission: ['find', function(callback) {
       if(actor === undefined) {
@@ -450,7 +466,6 @@ api.checkKeyPair = function(publicKeyPem, privateKeyPem, callback) {
         ex.message.indexOf('04065084') !== -1) {
         parsedPrivate = true;
       }
-      console.log(ex);
       err = ex;
     }
   } else {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bedrock-key",
   "version": "3.0.1-dev",
   "description": "Bedrock key",
-  "main": "./lib/main.js",
+  "main": "./lib",
   "scripts": {
     "test": "node ./bedrock/test.js test"
   },

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -8,7 +8,7 @@
 
 var bedrock = require('bedrock');
 var config = bedrock.config;
-var brKey = require('../lib/main.js');
+var brKey = require('../lib');
 
 describe('bedrock-key', function() {
   it('should validate a keypair', function(done) {


### PR DESCRIPTION
Lets you filter in keys that have a private key paired, i.e. if you only want to get keys that are capable of signing data.
