### PR TITLE
Public key access

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -237,15 +237,22 @@ api.getPublicKey = function(publicKey, actor, callback) {
       }
       brPermission.checkPermission(
         actor, PERMISSIONS.PUBLIC_KEY_ACCESS,
-        {resource: publicKey, translate: 'owner'},
-        callback);
+        {resource: publicKey, translate: 'owner'}, function(err) {
+          if(err && err.name === 'PermissionDenied') {
+            return callback();
+          }
+          callback(err, true);
+        });
     }]
   }, function(err, results) {
     if(err) {
       return callback(err);
     }
     var record = results.find;
-    var privateKey = record.publicKey.privateKey || null;
+    var privateKey = null;
+    if(results.checkPermission) {
+      privateKey = record.publicKey.privateKey || null;
+    }
     delete record.publicKey.privateKey;
     callback(null, record.publicKey, record.meta, privateKey);
   });
@@ -292,13 +299,17 @@ api.getPublicKeys = function(id, actor, options, callback) {
       brPermission.checkPermission(
         actor, PERMISSIONS.PUBLIC_KEY_ACCESS,
         {resource: id}, function(err) {
-          callback(err);
+          if(err && err.name === 'PermissionDenied') {
+            return callback();
+          }
+          callback(err, true);
         });
     }],
     clean: ['checkPermission', function(callback, results) {
       var records = results.find;
-      // remove private keys if no actor was provided
-      if(actor === undefined) {
+      // remove private keys if no actor was provided or the
+      // actor does not have permission to view
+      if(actor === undefined || !results.checkPermission) {
         records.forEach(function(record) {
           delete record.publicKey.privateKey;
         });


### PR DESCRIPTION
Before, non-authenticated users (which we treat as a null actor) could freely get public key data, but authenticated users were restricted if they did not have PUBLIC_KEY_ACCESS permissions for a particular public key resource. We would like all users to be able to access public key data, authenticated or non-authenticated, this patch adds a fix.
